### PR TITLE
Modify current shuffle partition write strategy

### DIFF
--- a/src/main/java/org/apache/spark/storage/pmof/PersistentMemoryPool.java
+++ b/src/main/java/org/apache/spark/storage/pmof/PersistentMemoryPool.java
@@ -13,20 +13,21 @@ import java.io.IOException;
  *
  * Data Structure
  * =============================================
- * stage_id: 0        shuffle_array[0].address
- * stage_id: 1        shuffle_array[1].address
+ * ===stage_array[0]===
+ * 0        shuffle_array[0].address  # contains all maps in this stage
+ * 1        shuffle_array[1].address
  * ... ...
  * stage_id: 1000     shuffle_array[999].address
  * ===shuffle_array[0]===
- * map_id: 0      block_array[0].address
- * map_id: 1      block_array[1].address
+ * 0      shuffle_block_array[0]   # contains all partitions in the shuffle map
+ * 1      shuffle_block_array[1]
  * ... ...
- * map_id: 1000   block_array[999].address
- * block_array[0]
- * block_array[1]
+ * ===shuffle_block[0]===
+ * 0      partition[0].address, partition[0].size
+ * 1      partition[1].address, partition[1].size
  * ... ...
- * ===shuffle_array[1]===
- * ===shuffle_array[2]===
+ * partition[0]: 32MB block -> 32MB Block -> ...
+ * partition[1]
  * ... ...
  * =============================================
  * */
@@ -84,12 +85,12 @@ public class PersistentMemoryPool {
         shuffleArray = pmHeap.memoryBlockFromAddress(Transactional.class, shuffle_array_addr);
       }
 
-      long block_array_addr = shuffleArray.getLong(Long.BYTES * shuffleId);
-      if (block_array_addr == 0 && partitionNum < 0) {
+      long shuffle_block_addr = shuffleArray.getLong(Long.BYTES * shuffleId);
+      if (shuffle_block_addr == 0 && partitionNum < 0) {
         logger.error("shuffle_" + stageId + "_" + shuffleId + " not exists");
         throw new ArrayIndexOutOfBoundsException();  
-      } else if (block_array_addr == 0) {
-        shuffleBlock = this.pmHeap.allocateMemoryBlock(Transactional.class, HEADER_SIZE + Long.BYTES * partitionNum);
+      } else if (shuffle_block_addr == 0) {
+        shuffleBlock = this.pmHeap.allocateMemoryBlock(Transactional.class, HEADER_SIZE + Long.BYTES * partitionNum * 2);
         shuffleBlock.setInt(0, partitionNum);
         shuffleArray.setLong(Long.BYTES * shuffleId, shuffleBlock.address());
       }
@@ -106,19 +107,19 @@ public class PersistentMemoryPool {
         shuffleArray = pmHeap.memoryBlockFromAddress(Transactional.class, shuffle_array_addr);
       }
 
-      long block_array_addr = shuffleArray.getLong(Long.BYTES * shuffleId);
-      if (block_array_addr == 0) {
+      long shuffle_block_addr = shuffleArray.getLong(Long.BYTES * shuffleId);
+      if (shuffle_block_addr == 0) {
         logger.error("getShuffleBlock: shuffle_" + stageId + "_" + shuffleId + " not exists");
         throw new ArrayIndexOutOfBoundsException();  
       } else {
-        shuffleBlock = pmHeap.memoryBlockFromAddress(Transactional.class, block_array_addr);
+        shuffleBlock = pmHeap.memoryBlockFromAddress(Transactional.class, shuffle_block_addr);
       }
       return shuffleBlock;
     }
 
     public MemoryBlock<Transactional> getPartitionBlock(int stageId, int shuffleId, int partitionId) {
       MemoryBlock<Transactional> shuffleBlock = getShuffleBlock(stageId, shuffleId);
-      long partition_block_addr = shuffleBlock.getLong(HEADER_SIZE + Long.BYTES * partitionId);
+      long partition_block_addr = shuffleBlock.getLong(HEADER_SIZE + Long.BYTES * partitionId * 2);
       if (partition_block_addr == 0) {
         logger.error("getPartitionBlock: shuffle_" + stageId + "_" + shuffleId + "_" + partitionId + " doesn't exist");
         throw new ArrayIndexOutOfBoundsException();
@@ -140,25 +141,60 @@ public class PersistentMemoryPool {
       }
 
       if (partitionLength > 0) {
-        MemoryBlock<Transactional> addr = pmHeap.allocateMemoryBlock(Transactional.class, partitionLength);
-        shuffleBlock.setLong(HEADER_SIZE + Long.BYTES * partitionId, addr.address());
+        // We are using linked block in partition, data structure will be like this
+        // next block addr(long) + this block content
+        MemoryBlock<Transactional> addr = pmHeap.allocateMemoryBlock(Transactional.class, Long.BYTES + partitionLength);
+        
+        long partition_block_addr = shuffleBlock.getLong(HEADER_SIZE + Long.BYTES * partitionId * 2);
+        long partition_size = shuffleBlock.getLong(HEADER_SIZE + Long.BYTES * (partitionId * 2 + 1));
+        MemoryBlock<Transactional> partition_block = null;
+        if (partition_block_addr == 0) {
+          logger.info("Add first partition block for shuffle_" + stageId + "_" + shuffleId + "_" + partitionId + ", length: " + partitionLength);
+          shuffleBlock.setLong(HEADER_SIZE + Long.BYTES * partitionId * 2, addr.address());
+        } else {
+          do { 
+            logger.info("Find last partition block for shuffle_" + stageId + "_" + shuffleId + "_" + partitionId + ", length: " + partitionLength);
+            partition_block = this.pmHeap.memoryBlockFromAddress(Transactional.class, partition_block_addr);
+            partition_block_addr = partition_block.getLong(0);
+          } while (partition_block_addr != 0);
+          partition_block.setLong(0, addr.address());
+        }
+        shuffleBlock.setLong(HEADER_SIZE + Long.BYTES * (partitionId * 2 + 1), partition_size + partitionLength);
       }
     }
 
     public void set(int stageId, int shuffleId, int partitionId, byte[] value) {
       MemoryBlock<Transactional> partitionBlock = getPartitionBlock(stageId, shuffleId, partitionId);
-
-      partitionBlock.copyFromArray(value, 0, 0, value.length);
-      partitionBlock.flush(0, value.length);
+      // find the last block of this partition
+      long partition_block_addr = partitionBlock.getLong(0);
+      while (partition_block_addr != 0) {
+        partitionBlock = this.pmHeap.memoryBlockFromAddress(Transactional.class, partition_block_addr);
+        partition_block_addr = partitionBlock.getLong(0);
+      }
+      partitionBlock.copyFromArray(value, 0, Long.BYTES, value.length);
+      partitionBlock.flush(0, Long.BYTES + value.length);
       logger.info("write data to shuffleId: " + shuffleId + ", partitionId: " + partitionId + ", length:" + value.length + ", size is " + partitionBlock.size());
     }
 
     public byte[] get(int stageId, int shuffleId, int partitionId) {
-      logger.info("Get Shuffle Block: shuffle_" + stageId + "_" + shuffleId + "_" + partitionId);
-      MemoryBlock<Transactional> partitionBlock = getPartitionBlock(stageId, shuffleId, partitionId);
+      MemoryBlock<Transactional> shuffleBlock = getShuffleBlock(stageId, shuffleId);
+      MemoryBlock<Transactional> partitionBlock = null;
+      long partition_block_addr = shuffleBlock.getLong(HEADER_SIZE + Long.BYTES * partitionId * 2);
+      long partition_length = shuffleBlock.getLong(HEADER_SIZE + Long.BYTES * (partitionId * 2 + 1));
 
-      byte[] bytes = new byte[toIntExact(partitionBlock.size())];
-      partitionBlock.copyToArray(0, bytes, 0, toIntExact(partitionBlock.size()));
+      // since current partition data is using linked block
+      // will need to put them into one byte array here
+      logger.info("Get Shuffle Block: shuffle_" + stageId + "_" + shuffleId + "_" + partitionId + ", size: " + partition_length);
+      byte[] bytes = new byte[toIntExact(partition_length)];
+      long cur = 0;
+      long tmp_length = 0;
+      do {
+        partitionBlock = this.pmHeap.memoryBlockFromAddress(Transactional.class, partition_block_addr);
+        tmp_length = partitionBlock.size() - Long.BYTES;
+        partitionBlock.copyToArray(Long.BYTES, bytes, toIntExact(cur), toIntExact(tmp_length));
+        cur += tmp_length;
+        partition_block_addr = partitionBlock.getLong(0);
+      } while (partition_block_addr != 0);
       return bytes;
     }
 

--- a/src/main/scala/org/apache/spark/storage/pmof/PersistentMemoryHandler.scala
+++ b/src/main/scala/org/apache/spark/storage/pmof/PersistentMemoryHandler.scala
@@ -38,8 +38,8 @@ private[spark] class PersistentMemoryHandler(
   }
 
   def write(stageId: Int, shuffleId: Int, partitionId: Int, data: Array[Byte]) = synchronized {
-    pmpool.addPartition(stageId, shuffleId, partitionId, data.size);
     if (data.size > 0) {
+      pmpool.addPartition(stageId, shuffleId, partitionId, data.size);
       pmpool.set(stageId, shuffleId, partitionId, data)
     }
   }


### PR DESCRIPTION
We used to buffer the whole partitions for all parallel tasks
then write into PM, and this will use too much memory

So, now I will divide partition data into linked block, per
block size is about 32MB.

Signed-off-by: Chendi Xue <chendi.xue@intel.com>