### PR TITLE
Set exact numMaps when creating pmpool

### DIFF
--- a/spark.conf.example
+++ b/spark.conf.example
@@ -9,10 +9,8 @@ spark.shuffle.pmof.enable_rdma true
 spark.shuffle.pmof.enable_pmem true
 
 # for persistent memory
-spark.shuffle.pmof.max_stage_num 1
-spark.shuffle.pmof.max_task_num 50000
+spark.shuffle.pmof.max_stage_num 100
 spark.shuffle.pmof.pmem_list /dev/dax0.0,/dev/dax1.0
-spark.shuffle.pmof.dev_core_set dax0:0-87,dax1:0-87
 
 # for rdma
 spark.shuffle.pmof.server_buffer_nums 32

--- a/src/main/scala/org/apache/spark/shuffle/pmof/PmemShuffleWriter.scala
+++ b/src/main/scala/org/apache/spark/shuffle/pmof/PmemShuffleWriter.scala
@@ -109,6 +109,8 @@ private[spark] class PmemShuffleWriter[K, V, C](
   private val numPartitions = partitioner.numPartitions
   private val serInstance: SerializerInstance = dep.serializer.newInstance()
   private val shuffleBlockId: String = ShuffleBlockId(stageId, mapId, 0).name 
+  private val numMaps = handle.numMaps
+  logDebug("This stage has "+ numMaps + " maps")
 
   val enable_rdma: Boolean = conf.getBoolean("spark.shuffle.pmof.enable_rdma", defaultValue = true)
   val enable_pmem: Boolean = conf.getBoolean("spark.shuffle.pmof.enable_pmem", defaultValue = true)
@@ -116,7 +118,7 @@ private[spark] class PmemShuffleWriter[K, V, C](
 
   val maxPoolSize: Long = conf.getLong("spark.shuffle.pmof.pmpool_size", defaultValue = 1073741824)
   val maxStages: Int = conf.getInt("spark.shuffle.pmof.max_stage_num", defaultValue = 1000)
-  val maxMaps: Int = conf.getInt("spark.shuffle.pmof.max_task_num", defaultValue = 1000)
+  val maxMaps: Int = numMaps
 
   var data_addr_map: Array[mutable.LinkedHashMap[Long, Int]] = Array.fill(numPartitions)(new mutable.LinkedHashMap[Long, Int])
 

--- a/src/main/scala/org/apache/spark/shuffle/pmof/PmofShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/pmof/PmofShuffleManager.scala
@@ -41,7 +41,8 @@ private[spark] class PmofShuffleManager(conf: SparkConf) extends ShuffleManager 
 
   override def getWriter[K, V](handle: ShuffleHandle, mapId: Int, context: TaskContext): ShuffleWriter[K, V] = {
     val env: SparkEnv = SparkEnv.get
-    numMapsForShuffle.putIfAbsent(handle.shuffleId, handle.asInstanceOf[BaseShuffleHandle[_, _, _]].numMaps)
+    val numMaps = handle.asInstanceOf[BaseShuffleHandle[_, _, _]].numMaps
+    numMapsForShuffle.putIfAbsent(handle.shuffleId, numMaps)
     if (enable_rdma) {
       RdmaTransferService.getTransferServiceInstance(env.blockManager, this)
     }

--- a/src/main/scala/org/apache/spark/storage/pmof/PersistentMemoryHandler.scala
+++ b/src/main/scala/org/apache/spark/storage/pmof/PersistentMemoryHandler.scala
@@ -38,12 +38,13 @@ private[spark] class PersistentMemoryHandler(
   var device: String = pmMetaHandler.getShuffleDevice(shuffleId);
   if(device == "") {
     //this shuffleId haven't been written before, choose a new device
-    logInfo("This a new shuffleBlock, find an unused device for this task.")
     val path_array_list = new java.util.ArrayList[String](path_list.asJava)
     device = pmMetaHandler.getUnusedDevice(path_array_list);
+    logInfo("This a new shuffleBlock, find an unused device:" + device + ", numMaps of this stage is " + maxShuffles)
+  } else {
+    logInfo("This a recently opened shuffleBlock, use the original device:" + device + ", numMaps of this stage is " + maxShuffles)
   }
   
-  logInfo("Open PersistentMemoryPool: " + device)
   val pmpool = new PersistentMemoryPool(device, maxStages, maxShuffles, poolSize)
   var rkey: Long = 0
 


### PR DESCRIPTION
Noticed that shufflewriter can get exact numMaps of corresponding stage, so fix here.

Signed-off-by: Chendi Xue <chendi.xue@intel.com>