### PR TITLE
Override spillable in PmemExternalSorter

### DIFF
--- a/src/main/scala/org/apache/spark/storage/pmof/PersistentMemoryHandler.scala
+++ b/src/main/scala/org/apache/spark/storage/pmof/PersistentMemoryHandler.scala
@@ -99,7 +99,7 @@ private[spark] class PersistentMemoryHandler(
     if (blockType == "shuffle") {
       ret_addr = pmpool.setMapPartition(numPartitions, stageId, shuffleId, partitionId, buf, clean)
     } else if (blockType == "reduce_spill") {
-      ret_addr = pmpool.setReducePartition(100000/*TODO: should be incrementable*/, stageId, partitionId, buf, clean)
+      ret_addr = pmpool.setReducePartition(10000000/*TODO: should be incrementable*/, stageId, partitionId, buf, clean)
     }
     ret_addr
   }


### PR DESCRIPTION
We noticed that more frequent spill helps pmof reduce GC overhead and performance is being better
configuration:
spark.shuffle.spill.pmof.MemoryThreshold 16777216 //16M

Signed-off-by: Chendi Xue <chendi.xue@intel.com>