### PR TITLE
 optimize pmem buffer in native code

### DIFF
--- a/core/src/main/java/org/apache/spark/storage/pmof/PmemBuffer.java
+++ b/core/src/main/java/org/apache/spark/storage/pmof/PmemBuffer.java
@@ -5,6 +5,7 @@ public class PmemBuffer {
         System.load("/usr/local/lib/libjnipmdk.so");
     }
     private native long nativeNewPmemBuffer();
+    private native long nativeNewPmemBufferBySize(long len);
     private native int nativeLoadPmemBuffer(long pmBuffer, long addr, int len);
     private native int nativeReadBytesFromPmemBuffer(long pmBuffer, byte[] bytes, int off, int len);
     private native int nativeWriteBytesToPmemBuffer(long pmBuffer, byte[] bytes, int off, int len);
@@ -17,6 +18,10 @@ public class PmemBuffer {
     long pmBuffer;
     PmemBuffer() {
       pmBuffer = nativeNewPmemBuffer();
+    }
+
+    PmemBuffer(long len) {
+      pmBuffer = nativeNewPmemBufferBySize(len);
     }
 
     void load(long addr, int len) {

--- a/core/src/main/scala/org/apache/spark/storage/pmof/PmemManagedBuffer.scala
+++ b/core/src/main/scala/org/apache/spark/storage/pmof/PmemManagedBuffer.scala
@@ -64,7 +64,6 @@ class PmemManagedBuffer(pmHandler: PersistentMemoryHandler, blockId: String) ext
   override def convertToNetty(): Object = {
     val data_length = size().toInt
     val in = createInputStream()
-    in.asInstanceOf[PmemInputStream].load(data_length)
     Unpooled.wrappedBuffer(in.asInstanceOf[PmemInputStream].getByteBufferDirectAddr, data_length, false)
   }
 }

--- a/native/src/PmemBuffer.h
+++ b/native/src/PmemBuffer.h
@@ -17,6 +17,14 @@ public:
     pos = 0;
     pos_dirty = 0;
   }
+  explicit PmemBuffer(long initial_buf_data_capacity) {
+    buf_data_capacity = initial_buf_data_capacity;
+    buf_data = (char*)malloc(sizeof(char) * buf_data_capacity);
+    remaining = 0;
+    remaining_dirty = 0;
+    pos = 0;
+    pos_dirty = 0;
+  }
 
   ~PmemBuffer() {
     if (buf_data != nullptr) {
@@ -35,14 +43,16 @@ public:
     }
 
     if (remaining > 0) {
-    	buf_data_capacity = remaining + pmem_data_len;
-      char* tmp_buf_data = buf_data;
-      buf_data = (char*)malloc(sizeof(char) * buf_data_capacity);
-      if (buf_data != nullptr && tmp_buf_data != nullptr) {
-        memcpy(buf_data, tmp_buf_data + pos, remaining);
+      if (buf_data_capacity < remaining+pmem_data_len) {
+        buf_data_capacity = remaining + pmem_data_len;
+        char* tmp_buf_data = buf_data;
+        buf_data = (char*)malloc(sizeof(char) * buf_data_capacity);
+        if (buf_data != nullptr && tmp_buf_data != nullptr) {
+          memcpy(buf_data, tmp_buf_data + pos, remaining);
+        }
+        free(tmp_buf_data);
       }
-      free(tmp_buf_data);
-    	pos = remaining;
+      pos = remaining;
       memcpy(buf_data + pos, pmem_data_addr, pmem_data_len);
     } else if (remaining == 0) {
 			if (buf_data_capacity < pmem_data_len) {

--- a/native/src/lib_jni_pmdk.cpp
+++ b/native/src/lib_jni_pmdk.cpp
@@ -67,6 +67,11 @@ JNIEXPORT jlong JNICALL Java_org_apache_spark_storage_pmof_PmemBuffer_nativeNewP
   return (long)(new PmemBuffer());
 }
 
+JNIEXPORT jlong JNICALL Java_org_apache_spark_storage_pmof_PmemBuffer_nativeNewPmemBufferBySize
+  (JNIEnv *env, jobject obj, jlong len) {
+  return (long)(new PmemBuffer(len));
+}
+
 JNIEXPORT void JNICALL Java_org_apache_spark_storage_pmof_PmemBuffer_nativeLoadPmemBuffer
   (JNIEnv *env, jobject obj, jlong pmBuffer, jlong addr, jint len) {
   ((PmemBuffer*)pmBuffer)->load((char*)addr, len);

--- a/native/src/lib_jni_pmdk.h
+++ b/native/src/lib_jni_pmdk.h
@@ -63,6 +63,9 @@ JNIEXPORT jlong JNICALL Java_org_apache_spark_storage_pmof_PersistentMemoryPool_
 JNIEXPORT jlong JNICALL Java_org_apache_spark_storage_pmof_PmemBuffer_nativeNewPmemBuffer
   (JNIEnv *, jobject);
 
+JNIEXPORT jlong JNICALL Java_org_apache_spark_storage_pmof_PmemBuffer_nativeNewPmemBufferBySize
+  (JNIEnv *, jobject, jlong);
+
 /*
  * Class:     lib_jni_pmdk
  * Method:    nativeLoadPmemBuffer


### PR DESCRIPTION
Current code needs to malloc new buffer, then copy content from existing buffer to new buffer when load data from persistent memory.
The optimized code preserves buffer with wanted size when creating pmem inputream, then loads data from persistent memory in append mode.

Signed-off-by: Haodong Tang <haodong.tang@intel.com>