### PR TITLE
[CPP] Missing spdlog header in Log.h

### DIFF
--- a/rpmp/pmpool/Log.h
+++ b/rpmp/pmpool/Log.h
@@ -14,6 +14,8 @@
 
 #include "Config.h"
 #include "spdlog/spdlog.h"
+#include "spdlog/sinks/basic_file_sink.h"
+#include "spdlog/sinks/stdout_color_sinks.h"
 
 class Log {
  public:


### PR DESCRIPTION
Signed-off-by: Chendi.Xue <chendi.xue@intel.com>