### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ git clone https://github.com/Intel-bigdata/Spark-PMoF.git
 cd Spark-PMoF; mvn package -DskipTests
 ```
 
+If the pmem hardware is ready,it's useful to test by removing the `-DskipTests` option:
+
+```shell
+mvn package
+```
+
 ## Benchmark
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Make sure you got [HPNL](https://github.com/Intel-bigdata/HPNL) installed.
 
 ```shell
 git clone https://github.com/Intel-bigdata/Spark-PMoF.git
-cd Spark-PMoF; mvn package
+cd Spark-PMoF; mvn package -DskipTests
 ```
 
 ## Benchmark
@@ -26,7 +26,7 @@ This plugin current supports Spark 2.3 and works well on various Network fabrics
 ```shell
 spark.driver.extraClassPath Spark-PMoF-PATH/target/sso-0.1-jar-with-dependencies.jar
 spark.executor.extraClassPath Spark-PMoF-PATH/target/sso-0.1-jar-with-dependencies.jar
-spark.shuffle.manager org.apache.spark.shuffle.pmof.RdmaShuffleManager
+spark.shuffle.manager org.apache.spark.shuffle.pmof.PmofShuffleManager
 ```
 
 ## Contact


### PR DESCRIPTION
Generally speaking, there is no AEP device in the compilation environment, so you need to skip the test when compiling with -DskipTests to avoid troubles for developers.
The spark.shuffle.manager main class has been updated for a long time, and now the documentation is wrong, and users cannot use this configuration to run PMoF.