### PR TITLE
fix fsdax mode in NUMA

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/pmof/PersistentMemoryHandler.scala
+++ b/core/src/main/scala/org/apache/spark/storage/pmof/PersistentMemoryHandler.scala
@@ -25,6 +25,7 @@ private[spark] class PersistentMemoryHandler(
   // need to use a locked file to get which pmem device should be used.
   val pmMetaHandler: PersistentMemoryMetaHandler = new PersistentMemoryMetaHandler(root_dir)
   var device: String = pmMetaHandler.getShuffleDevice(shuffleId)
+  var poolFile = ""
   if(device == "") {
     //this shuffleId haven't been written before, choose a new device
     val path_array_list = new java.util.ArrayList[String](path_list.asJava)
@@ -33,15 +34,16 @@ private[spark] class PersistentMemoryHandler(
     val dev = Paths.get(device)
     if (Files.isDirectory(dev)) {
       // this is fsdax, add a subfile
-      device += "/shuffle_block_" + UUID.randomUUID().toString()
-      logInfo("This is a fsdax, filename:" + device)
+      poolFile = device + "/shuffle_block_" + UUID.randomUUID().toString()
+      logInfo("This is a fsdax, filename:" + poolFile)
     } else {
-      logInfo("This is a devdax, name:" + device)
+      poolFile = device
+      logInfo("This is a devdax, name:" + poolFile)
       poolSize = 0
     }
   }
   
-  val pmpool = new PersistentMemoryPool(device, poolSize)
+  val pmpool = new PersistentMemoryPool(poolFile, poolSize)
   var rkey: Long = 0
 
 


### PR DESCRIPTION
When the device is fsdax mode, 
an explicit size must be specified. 
Fsdax will change the name of the pool file, 
and the device name in pmemCoreMap does not change at this time, 
so NUMA binding cannot be performed.