### PR TITLE
add size param in fsdax

### DIFF
--- a/native/src/lib_jni_pmdk.cpp
+++ b/native/src/lib_jni_pmdk.cpp
@@ -5,7 +5,7 @@
 JNIEXPORT jlong JNICALL Java_org_apache_spark_storage_pmof_PersistentMemoryPool_nativeOpenDevice
   (JNIEnv *env, jclass obj, jstring path, jlong size) {
   const char *CStr = env->GetStringUTFChars(path, 0);
-  pmemkv* kv= new pmemkv(CStr);
+  pmemkv* kv= new pmemkv(CStr, size);
   env->ReleaseStringUTFChars(path, CStr);
   return (long)kv;
 }


### PR DESCRIPTION
When the device is fsdax mode, 
an explicit size must be specified. 
when devdax,size is always 0.