### PR TITLE
enable fsdax mode in native

### DIFF
--- a/native/src/pmemkv.h
+++ b/native/src/pmemkv.h
@@ -92,8 +92,8 @@ key_3 --> block_meta_list_3[block_meta, block_meta, block_meta]
 */
 class pmemkv {
   public:
-    explicit pmemkv(const char* dev_path_) : pmem_pool(nullptr), dev_path(dev_path_), bp(nullptr) {
-      if (create()) {
+    explicit pmemkv(const char* dev_path_, long size) : pmem_pool(nullptr), dev_path(dev_path_), bp(nullptr) {
+      if (create(size)) {
         int res = open();
         if (res) {
           std::cout << "failed to open pmem pool, errmsg: " << pmemobj_errormsg() << std::endl; 
@@ -300,12 +300,12 @@ class pmemkv {
       return (uint64_t)pmem_pool;
     }
   private:
-    int create() {
+    int create(long size) {
       // debug setting
       int sds_write_value = 0;
       pmemobj_ctl_set(nullptr, "sds.at_create", &sds_write_value);
 
-      pmem_pool = pmemobj_create(dev_path, PMEMKV_LAYOUT_NAME, 0, 0666);
+      pmem_pool = pmemobj_create(dev_path, PMEMKV_LAYOUT_NAME, size, 0666);
       if (pmem_pool == nullptr) {
         return -1;
       }


### PR DESCRIPTION
enable fsdax mode in native:add param size in create method.
When using devdax, the size is changed to 0 in the upper level code