### PR TITLE
[PMoF-96] delete fsdax files independently

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/pmof/PersistentMemoryHandler.scala
+++ b/core/src/main/scala/org/apache/spark/storage/pmof/PersistentMemoryHandler.scala
@@ -85,9 +85,20 @@ private[spark] class PersistentMemoryHandler(
   }
 
   def close(): Unit = synchronized {
-    pmpool.close()
-    pmMetaHandler.remove()
-    if(isFsdaxFile) new File(poolFile).delete()
+      if (isFsdaxFile) {
+      try {
+        if (new File(poolFile).delete()) {
+          logInfo("File deleted successfully: " + poolFile)
+        } else {
+          logWarning("Failed to delete file: " + poolFile)
+        }
+      } catch {
+        case e: Exception => e.printStackTrace()
+      }
+    } else {
+      pmpool.close()
+      pmMetaHandler.remove()
+    }
   }
 
   def getRootAddr(): Long = {


### PR DESCRIPTION
FSDAX mode does not need to clean up the pool 
and can directly delete files using POSIX operations.
Separate the fsdax file deletion operation from devdax.