### PR TITLE
[BUG-FIX][RPMP]Get config folder included in built artifact folder

### DIFF
--- a/rpmp/CMakeLists.txt
+++ b/rpmp/CMakeLists.txt
@@ -51,3 +51,5 @@ target_link_libraries(chashtest pmpool spdlog hiredis jsoncpp)
 target_link_libraries(main pmpool spdlog hiredis jsoncpp)
 target_link_libraries(proxyMain pmpool spdlog hiredis jsoncpp)
 target_link_libraries(client pmpool spdlog hiredis jsoncpp)
+
+file(COPY ${PROJECT_SOURCE_DIR}/config DESTINATION .)


### PR DESCRIPTION
As the title. 